### PR TITLE
Add unified database layer for NeuroTrack

### DIFF
--- a/src/BehavioralModificationEngine.js
+++ b/src/BehavioralModificationEngine.js
@@ -1,1 +1,112 @@
+const { EventEmitter } = require('eventemitter3');
+const BehavioralEventsDAO = require('../dao/BehavioralEventsDAO');
+const { v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
 
+class BehavioralModificationEngine extends EventEmitter {
+  constructor(eventBus) {
+    super();
+    this.eventBus = eventBus;
+    this.focusIntervals = new RingBuffer(100);
+    this.contextSwitches = new RingBuffer(100);
+    this.sustainedFocusThreshold = 5; // Example threshold
+    this.behavioralEventsDAO = new BehavioralEventsDAO();
+
+    this.eventBus.subscribe('focusChange', this.trackFocusEvent.bind(this));
+    this.eventBus.subscribe('idleChange', this.trackContextSwitch.bind(this));
+  }
+
+  async trackFocusEvent(data) {
+    const eventData = {
+      eventId: uuidv4(),
+      eventType: 'focusChange',
+      timestamp: new Date(),
+      metadata: data
+    };
+    this.focusIntervals.push(eventData);
+    this.eventBus.publish('focusChange', eventData);
+
+    try {
+      await this.behavioralEventsDAO.insertRecord('focusChange', JSON.stringify(data));
+    } catch (error) {
+      console.error('Error inserting focus event:', error);
+    }
+
+    if (this.focusIntervals.getItems().length >= this.sustainedFocusThreshold) {
+      this.triggerRewardEvent();
+    }
+  }
+
+  async trackContextSwitch(data) {
+    const eventData = {
+      eventId: uuidv4(),
+      eventType: 'contextSwitch',
+      timestamp: new Date(),
+      metadata: data
+    };
+    this.contextSwitches.push(eventData);
+    this.eventBus.publish('contextSwitch', eventData);
+
+    try {
+      await this.behavioralEventsDAO.insertRecord('contextSwitch', JSON.stringify(data));
+    } catch (error) {
+      console.error('Error inserting context switch event:', error);
+    }
+
+    if (this.contextSwitches.getItems().length >= this.sustainedFocusThreshold) {
+      this.triggerProductivityDegradationEvent();
+    }
+  }
+
+  triggerRewardEvent() {
+    const rewardEvent = {
+      eventId: uuidv4(),
+      eventType: 'RewardEvent',
+      timestamp: new Date(),
+      metadata: {}
+    };
+    this.eventBus.publish('RewardEvent', rewardEvent);
+
+    try {
+      this.behavioralEventsDAO.insertRecord('RewardEvent', JSON.stringify({}));
+    } catch (error) {
+      console.error('Error inserting reward event:', error);
+    }
+  }
+
+  triggerProductivityDegradationEvent() {
+    const degradationEvent = {
+      eventId: uuidv4(),
+      eventType: 'productivityDegradation',
+      timestamp: new Date(),
+      metadata: {}
+    };
+    this.eventBus.publish('productivityDegradation', degradationEvent);
+
+    try {
+      this.behavioralEventsDAO.insertRecord('productivityDegradation', JSON.stringify({}));
+    } catch (error) {
+      console.error('Error inserting productivity degradation event:', error);
+    }
+  }
+}
+
+class RingBuffer {
+  constructor(size) {
+    this.size = size;
+    this.buffer = [];
+  }
+
+  push(item) {
+    if (this.buffer.length >= this.size) {
+      this.buffer.shift();
+    }
+    this.buffer.push(item);
+  }
+
+  getItems() {
+    return this.buffer;
+  }
+}
+
+module.exports = BehavioralModificationEngine;

--- a/src/FocusTrackingEngine.js
+++ b/src/FocusTrackingEngine.js
@@ -2,7 +2,11 @@ const { EventEmitter } = require('eventemitter3');
 const WindowsFocusTracker = require('./platforms/WindowsFocusTracker');
 const MacOSFocusTracker = require('./platforms/MacOSFocusTracker');
 const LinuxFocusTracker = require('./platforms/LinuxFocusTracker');
-
+const FocusRecordsDAO = require('../dao/FocusRecordsDAO');
+const { v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
+const path = require('path');
+const fs = require('fs');
 
 class FocusTrackingEngine extends EventEmitter {
   constructor(eventBus) {
@@ -19,6 +23,7 @@ class FocusTrackingEngine extends EventEmitter {
 
     this.startIdleCheck();
 
+    this.encryptionKey = this.loadOrGenerateKey();
   }
 
   getPlatformTracker() {

--- a/src/tests/BehavioralEventsDAO.test.js
+++ b/src/tests/BehavioralEventsDAO.test.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+const db = require('../db/connection');
+const BehavioralEventsDAO = require('../dao/BehavioralEventsDAO');
+
+describe('BehavioralEventsDAO', () => {
+  beforeEach(async () => {
+    await BehavioralEventsDAO.createTable();
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve, reject) => {
+      db.run('DELETE FROM behavioral_events', (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+
+  it('should add a new record', async () => {
+    const eventType = 'focusChange';
+    const metadata = JSON.stringify({ key: 'value' });
+
+    const recordId = await BehavioralEventsDAO.insertRecord(eventType, metadata);
+
+    const records = await BehavioralEventsDAO.queryRecords();
+    expect(records).to.have.lengthOf(1);
+    expect(records[0]).to.include({ event_type: eventType, metadata });
+  });
+
+  it('should query records', async () => {
+    const eventType1 = 'focusChange';
+    const metadata1 = JSON.stringify({ key: 'value1' });
+    const eventType2 = 'contextSwitch';
+    const metadata2 = JSON.stringify({ key: 'value2' });
+
+    await BehavioralEventsDAO.insertRecord(eventType1, metadata1);
+    await BehavioralEventsDAO.insertRecord(eventType2, metadata2);
+
+    const records = await BehavioralEventsDAO.queryRecords();
+    expect(records).to.have.lengthOf(2);
+    expect(records[0]).to.include({ event_type: eventType2, metadata: metadata2 });
+    expect(records[1]).to.include({ event_type: eventType1, metadata: metadata1 });
+  });
+});


### PR DESCRIPTION
Update `FocusTrackingEngine.js` and `BehavioralModificationEngine.js` to integrate with DAOs for persisting focus and behavioral events.

* **FocusTrackingEngine.js**
  - Add `FocusRecordsDAO` integration to persist focus/idle events.
  - Add methods to handle focus and idle changes.
  - Add encryption key generation and loading.

* **BehavioralModificationEngine.js**
  - Add `BehavioralEventsDAO` integration to persist reward triggers and productivity degradation events.
  - Add methods to track focus events, context switches, and trigger reward/productivity degradation events.
  - Add `RingBuffer` class for managing focus intervals and context switches.

* **Tests**
  - Update `FocusRecordsDAO.test.js` to use persistent SQLite database connection and add tests for new methods.
  - Update `BehavioralModificationEngine.test.js` to use persistent SQLite database connection and add tests for new methods.
  - Update `FocusTrackingEngine.test.js` to use persistent SQLite database connection and add tests for integration with `FocusRecordsDAO`.
  - Add `BehavioralEventsDAO.test.js` to test `BehavioralEventsDAO` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/NeuroTrack/pull/18?shareId=5fb0e1ef-b1b1-4433-864f-4271caad4e0f).