### PR TITLE
Enhance CognitiveEnhancementModule with break scheduling and compliance tracking

### DIFF
--- a/src/CognitiveEnhancementModule.js
+++ b/src/CognitiveEnhancementModule.js
@@ -1,7 +1,57 @@
+const BehavioralEventsDAO = require('../dao/BehavioralEventsDAO');
+
 class CognitiveEnhancementModule {
   constructor(eventBus) {
     this.eventBus = eventBus;
+    this.breakInterval = 25 * 60 * 1000; // 25 minutes in milliseconds
+    this.breakDuration = 5 * 60 * 1000; // 5 minutes in milliseconds
+    this.breakTimer = null;
+    this.behavioralEventsDAO = new BehavioralEventsDAO();
 
+    this.eventBus.subscribe('update-goal-time', this.handleGoalFocusTimeUpdate.bind(this));
+  }
+
+  handleGoalFocusTimeUpdate(goalFocusTime) {
+    if (goalFocusTime >= this.breakInterval) {
+      this.scheduleBreak();
+    }
+  }
+
+  scheduleBreak() {
+    this.breakTimer = setTimeout(() => {
+      this.publishBreakScheduledEvent();
+    }, this.breakDuration);
+  }
+
+  publishBreakScheduledEvent() {
+    const breakEvent = {
+      eventType: 'BreakScheduled',
+      timestamp: new Date(),
+      metadata: {}
+    };
+    this.eventBus.publish('BreakScheduled', breakEvent);
+  }
+
+  trackCompliance(isCompliant) {
+    const complianceEvent = {
+      eventType: isCompliant ? 'BreakAccepted' : 'BreakDismissed',
+      timestamp: new Date(),
+      metadata: {}
+    };
+    this.eventBus.publish('BreakCompliance', complianceEvent);
+
+    this.behavioralEventsDAO.insertRecord(complianceEvent.eventType, JSON.stringify(complianceEvent.metadata));
+  }
+
+  skipBreak() {
+    const skippedBreakEvent = {
+      eventType: 'SkippedBreak',
+      timestamp: new Date(),
+      metadata: {}
+    };
+    this.eventBus.publish('BreakCompliance', skippedBreakEvent);
+
+    this.behavioralEventsDAO.insertRecord(skippedBreakEvent.eventType, JSON.stringify(skippedBreakEvent.metadata));
   }
 }
 

--- a/src/tests/CognitiveEnhancementModule.test.js
+++ b/src/tests/CognitiveEnhancementModule.test.js
@@ -2,17 +2,55 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const EventBus = require('../eventBus');
 const CognitiveEnhancementModule = require('../CognitiveEnhancementModule');
-
+const BehavioralEventsDAO = require('../dao/BehavioralEventsDAO');
 
 describe('CognitiveEnhancementModule', () => {
   let eventBus;
   let cognitiveEnhancementModule;
+  let behavioralEventsDAO;
 
   beforeEach(() => {
     eventBus = new EventBus();
     cognitiveEnhancementModule = new CognitiveEnhancementModule(eventBus);
+    behavioralEventsDAO = new BehavioralEventsDAO();
   });
 
+  it('should schedule a break after X minutes of continuous goal focus', (done) => {
+    const goalFocusTime = 25 * 60 * 1000; // 25 minutes in milliseconds
+    cognitiveEnhancementModule.handleGoalFocusTimeUpdate(goalFocusTime);
 
+    setTimeout(() => {
+      expect(cognitiveEnhancementModule.breakTimer).to.not.be.null;
+      done();
+    }, 100);
+  });
+
+  it('should publish BreakScheduled event for the UI', (done) => {
+    const breakScheduledSpy = sinon.spy();
+    eventBus.subscribe('BreakScheduled', breakScheduledSpy);
+
+    cognitiveEnhancementModule.scheduleBreak();
+
+    setTimeout(() => {
+      expect(breakScheduledSpy.calledOnce).to.be.true;
+      done();
+    }, 100);
+  });
+
+  it('should track user compliance and store in BehavioralEventsDAO', async () => {
+    const isCompliant = true;
+    await cognitiveEnhancementModule.trackCompliance(isCompliant);
+
+    const records = await behavioralEventsDAO.queryRecords();
+    expect(records).to.have.lengthOf(1);
+    expect(records[0]).to.include({ event_type: 'BreakAccepted' });
+  });
+
+  it('should track skipped break penalty when user skips breaks', async () => {
+    await cognitiveEnhancementModule.skipBreak();
+
+    const records = await behavioralEventsDAO.queryRecords();
+    expect(records).to.have.lengthOf(1);
+    expect(records[0]).to.include({ event_type: 'SkippedBreak' });
   });
 });


### PR DESCRIPTION
Implement neural disruptors or micro-breaks, publish events for the UI, track user compliance, and allow skipping breaks with a penalty in `CognitiveEnhancementModule.js`.

* **Break Scheduling and Event Publishing**
  - Implement scheduling of neural disruptors or micro-breaks after 25 minutes of continuous "goal focus".
  - Publish a `BreakScheduled` event for the UI to render as a modal or intrusive pop-up.

* **User Compliance Tracking**
  - Track user compliance (accept or dismiss break) and store compliance data in `BehavioralEventsDAO`.
  - Allow users to skip breaks if in hyper-focus, but track a "skippedBreak" penalty and store it in `BehavioralEventsDAO`.

* **Testing**
  - Add tests to verify break scheduling after 25 minutes of continuous "goal focus".
  - Add tests to verify `BreakScheduled` event publishing for the UI.
  - Add tests to verify user compliance tracking and storing in `BehavioralEventsDAO`.
  - Add tests to verify tracking of "skippedBreak" penalty when user skips breaks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/NeuroTrack/pull/22?shareId=aedbbdd8-950f-409c-ae80-f55cca57d2c0).