### PR TITLE
Integrate a simple local ML pipeline

### DIFF
--- a/src/DataAndMLPipeline.js
+++ b/src/DataAndMLPipeline.js
@@ -1,11 +1,45 @@
 const tf = require('@tensorflow/tfjs-node');
 
-
 class DataAndMLPipeline {
   constructor(eventBus) {
     this.eventBus = eventBus;
     this.model = null;
+    this.loadModel();
+  }
 
+  async loadModel() {
+    try {
+      this.model = await tf.loadLayersModel('file://path/to/model.json');
+    } catch (error) {
+      console.log('Error loading model, creating a new one.');
+      this.model = this.createPlaceholderModel();
+    }
+  }
+
+  createPlaceholderModel() {
+    const model = tf.sequential();
+    model.add(tf.layers.dense({ units: 1, inputShape: [3], activation: 'sigmoid' }));
+    model.compile({ optimizer: 'adam', loss: 'binaryCrossentropy' });
+    return model;
+  }
+
+  preprocessData(data) {
+    const { timeOfDay, currentAppUsage, pastContextSwitches } = data;
+    return tf.tensor2d([[timeOfDay, currentAppUsage, pastContextSwitches]]);
+  }
+
+  async performInference(data) {
+    const preprocessedData = this.preprocessData(data);
+    const prediction = this.model.predict(preprocessedData);
+    const distractionProbability = prediction.dataSync()[0];
+    this.eventBus.publish('distractionProbabilityUpdated', { distractionProbability });
+  }
+
+  async replaceOrRetrainModel(newData, newLabels) {
+    const xs = tf.tensor2d(newData);
+    const ys = tf.tensor2d(newLabels);
+    await this.model.fit(xs, ys, { epochs: 10 });
+    await this.model.save('file://path/to/model.json');
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,15 @@ timerManager.initializeDatabase(); // P27d7
 // Subscribe to focus/idle events from FocusTrackingEngine and write them to the local DB using FocusRecordsDAO
 eventBus.subscribe('focusChange', (data) => {
   console.log('Focus Change Event:', data);
+  dataAndMLPipeline.performInference(data); // P227a
+});
+
 eventBus.subscribe('idleChange', (data) => {
   console.log('Idle Change Event:', data);
   focusRecordsDAO.addRecord(data);
   behavioralModificationEngine.trackFocusEvent(data);
   cognitiveEnhancementModule.detectDeepWorkSessions(data);
+  dataAndMLPipeline.performInference(data); // P227a
 });
 
 // Subscribe to reward and degradation events from BehavioralModificationEngine and log them to the console
@@ -62,7 +66,7 @@ eventBus.subscribe('distractionProbabilityUpdated', (data) => {
 // Subscribe to daily session events and trigger the ML pipeline
 eventBus.subscribe('dailySession', (data) => {
   console.log('Daily Session Event:', data);
-  dataAndMLPipeline.handleDailySession(data);
+  dataAndMLPipeline.handleDailySession(data); // Pa821
 });
 
 // Subscribe to break events from CognitiveEnhancementModule


### PR DESCRIPTION
Integrate a simple local ML pipeline in `DataAndMLPipeline.js`.

* **DataAndMLPipeline.js**
  - Import `tf` from `@tensorflow/tfjs-node`.
  - Add a method to load or create a placeholder TensorFlow.js model.
  - Add a method to preprocess data for the model.
  - Add a method to perform inference and publish "distractionProbabilityUpdated" event.
  - Add a method to replace or retrain the model locally.

* **index.js**
  - Subscribe to focus/idle events and trigger the ML pipeline.
  - Subscribe to daily session events and trigger the ML pipeline.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/NeuroTrack/pull/23?shareId=6b110f82-eb86-4511-a491-faeb0235ec10).