### PR TITLE
One Timer Two Categories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,13 +78,9 @@ eventBus.subscribe('BreakCompliance', (data) => {
   console.log('Break Compliance Event:', data);
 });
 
-// Add event listeners for start-goal-timer and start-non-goal-timer events
-ipcMain.on('start-goal-timer', () => {
-  timerManager.startGoalFocusTimer();
-});
-
-ipcMain.on('start-non-goal-timer', () => {
-  timerManager.startNonGoalFocusTimer();
+// Add event listeners for start-focus-timer event
+ipcMain.on('start-focus-timer', (event, focusType) => {
+  timerManager.startFocusTimer(focusType);
 });
 
 // Store daily totals at the end of the day

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,33 +3,24 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NeuroTrack Timers</title>
+    <title>NeuroTrack Timer</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div id="goal-timer">
-        <h2>Goal Timer</h2>
-        <p id="goal-time">00:00:00</p>
-    </div>
-    <div id="non-goal-timer">
-        <h2>Non-Goal Timer</h2>
-        <p id="non-goal-time">00:00:00</p>
+    <div id="timer">
+        <h2>Focus Timer</h2>
+        <p id="time">00:00:00</p>
     </div>
     <button id="goal-button">Goal</button>
     <button id="non-goal-button">Non-Goal</button>
     <script src="preload.js"></script>
     <script>
-        const goalTimeElement = document.getElementById('goal-time');
-        const nonGoalTimeElement = document.getElementById('non-goal-time');
+        const timeElement = document.getElementById('time');
         const goalButton = document.getElementById('goal-button');
         const nonGoalButton = document.getElementById('non-goal-button');
 
-        window.timers.updateGoalTime((time) => {
-            goalTimeElement.textContent = new Date(time * 1000).toISOString().substr(11, 8);
-        });
-
-        window.timers.updateNonGoalTime((time) => {
-            nonGoalTimeElement.textContent = new Date(time * 1000).toISOString().substr(11, 8);
+        window.timers.updateTime((time) => {
+            timeElement.textContent = new Date(time * 1000).toISOString().substr(11, 8);
         });
 
         goalButton.addEventListener('click', () => {

--- a/ui/preload.js
+++ b/ui/preload.js
@@ -10,11 +10,8 @@ contextBridge.exposeInMainWorld('electron', {
 });
 
 contextBridge.exposeInMainWorld('timers', {
-    updateGoalTime: (callback) => {
-        ipcRenderer.on('update-goal-time', (event, time) => callback(time));
-    },
-    updateNonGoalTime: (callback) => {
-        ipcRenderer.on('update-non-goal-time', (event, time) => callback(time));
+    updateTime: (callback) => {
+        ipcRenderer.on('update-time', (event, time) => callback(time));
     }
 });
 
@@ -30,13 +27,8 @@ window.addEventListener('DOMContentLoaded', () => {
         ipcRenderer.send('start-non-goal-timer');
     });
 
-    ipcRenderer.on('update-goal-time', (event, time) => {
-        const goalTimeElement = document.getElementById('goal-time');
-        goalTimeElement.textContent = new Date(time * 1000).toISOString().substr(11, 8);
-    });
-
-    ipcRenderer.on('update-non-goal-time', (event, time) => {
-        const nonGoalTimeElement = document.getElementById('non-goal-time');
-        nonGoalTimeElement.textContent = new Date(time * 1000).toISOString().substr(11, 8);
+    ipcRenderer.on('update-time', (event, time) => {
+        const timeElement = document.getElementById('time');
+        timeElement.textContent = new Date(time * 1000).toISOString().substr(11, 8);
     });
 });


### PR DESCRIPTION
Update the codebase to use a single timer approach for tracking both goal and non-goal focus time.

* **TimerManager.js**
  - Update to use a single timer that tracks both goal and non-goal focus time.
  - Remove separate timers for goal and non-goal focus time.
  - Update `startGoalFocusTimer` and `startNonGoalFocusTimer` methods to use the single timer.
  - Add `totalFocusTime` and `currentFocusType` properties.
  - Update `emitTimeUpdate` method to emit total, goal, and non-goal focus times.

* **index.html**
  - Update to display a single timer.
  - Remove separate elements for goal and non-goal timers.
  - Update script to handle a single timer.

* **preload.js**
  - Update to handle a single event for updating the timer.
  - Remove separate events for updating goal and non-goal timers.

* **index.js**
  - Update to subscribe to a single event for starting the timer.
  - Remove separate events for starting goal and non-goal timers.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/NeuroTrack?shareId=XXXX-XXXX-XXXX-XXXX).