### PR TITLE
Fix missing tfjs_binding.node error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "electron ."
   },
   "dependencies": {
+    "@tensorflow/tfjs-node": "^4.22.0",
     "electron": "^13.6.9",
     "eventemitter3": "^4.0.7",
     "sqlite3": "^5.1.7",


### PR DESCRIPTION
Add `@tensorflow/tfjs-node` as a dependency in `package.json`.

* Add `@tensorflow/tfjs-node` version `^4.22.0` to the `dependencies` section of `package.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shuddl/NeuroTrack/pull/40?shareId=b57fbbe0-d595-4fbe-acc1-22a728ee6c64).