### PR TITLE
Fix undefined references in BehavioralModificationEngine

### DIFF
--- a/src/BehavioralModificationEngine.js
+++ b/src/BehavioralModificationEngine.js
@@ -7,6 +7,12 @@ const DataAndMLPipeline = require('./DataAndMLPipeline');
 class BehavioralModificationEngine extends EventEmitter {
   constructor(eventBus, timerManager) {
     super();
+    if (!eventBus) {
+      throw new Error('eventBus is required');
+    }
+    if (!timerManager) {
+      throw new Error('timerManager is required');
+    }
     this.eventBus = eventBus;
     this.timerManager = timerManager;
     this.focusIntervals = new RingBuffer(100);


### PR DESCRIPTION
Add checks for undefined `eventBus` and `timerManager` in `BehavioralModificationEngine` constructor.

* Add error handling to throw an error if `eventBus` or `timerManager` is undefined in the constructor.
* Ensure `this.eventBus` and `this.timerManager` are defined before using them in the constructor.

